### PR TITLE
docs(readme): fix contribution guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ We're open to PRs. Two things matter most:
 1. **Don't break the multi-agent contracts.** Each agent has explicit input/output shapes — see `types/agents.ts`.
 2. **Tests gate everything.** Vitest 1894/1894 must stay green. Add tests for new lib/service files.
 
-See [`CLAUDE.md`](CLAUDE.md) for the repo's "house style" + agent design notes.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the repo's contribution guide.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,7 +331,7 @@ npm run dev:ws             # Yjs WebSocket server on :1234
 1. **不要破坏多 Agent 契约.** 每个 agent 输入输出 shape 在 `types/agents.ts`.
 2. **测试是底线.** Vitest 1711/1711 必须保持绿. 新加 lib/service 必须配测试.
 
-详见 [`CLAUDE.md`](CLAUDE.md) — 仓库的"代码风格"和 agent 设计笔记.
+详见 [`CONTRIBUTING.md`](CONTRIBUTING.md) — 仓库贡献指南.
 
 ---
 


### PR DESCRIPTION
## Summary

- Update the English and Chinese README contribution section to link to `CONTRIBUTING.md` instead of missing `CLAUDE.md`.

## Proof

- Current tree has `CONTRIBUTING.md` tracked and no root `CLAUDE.md`.
- Fresh duplicate checks for open/all PRs and issues matching `CLAUDE.md README` returned no results.
- Repo-local CLA/DCO text search over `.github`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and READMEs returned no CLA/DCO requirement text.

## Verification

- `git diff --check`
- `git diff HEAD^..HEAD --check`
- Node link check confirmed both READMEs now point to existing `CONTRIBUTING.md` and no longer point to `CLAUDE.md`.

No npm build/test run: this is a README-only link target correction with no application code, package metadata, or generated docs output changed.