### PR TITLE
feat(image): add Atlas Cloud provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,16 @@ GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
 # 若这把 key 只想给文本 LLM 用、不想让它接管图像链,设 0 明确关掉(v12.239)
 GEMINI_IMAGE_ENABLED=
 
+# Atlas Cloud Seedream —— 显式开启后才加入图像 fallback 链，避免仅配置 key 时产生意外费用。
+# 当前适配文生图；有参考图的镜头会自动跳过，不会静默丢弃角色/风格参考。
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_IMAGE_ENABLED=
+ATLASCLOUD_IMAGE_MODEL=bytedance/seedream-v5.0-lite
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai
+# 可选：jpeg（默认）或 png；异步 prediction 最长等待时间默认 300000ms。
+ATLASCLOUD_IMAGE_OUTPUT_FORMAT=jpeg
+ATLASCLOUD_IMAGE_POLL_TIMEOUT_MS=300000
+
 # v12.239:部署在受信反向代理之后才置 1 —— 否则限流一律不采信 X-Forwarded-For
 # (那个头攻击者可控:换 IP 能绕过登录爆破限流,填别人 IP 能打满其限流桶)
 TRUST_PROXY_HEADERS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Atlas Cloud Seedream image provider** — adds an opt-in text-to-image fallback backed by Atlas Cloud's asynchronous prediction API. Submission is never retried, prediction polling is bounded, and reference-bound shots skip the provider rather than dropping their references.
 - **Multi-character face lock — Phase 1** (`/dashboard/create`) — upload 1-3 main character faces (主角 A / B / C) at creation time with name + role preset (lead 125 / antagonist 125 / supporting 100 / cameo 80) → cw. Files via local upload **or** image URL. Persisted in new `projects.locked_characters` JSON column; first character is also synced into the existing `primary_character_ref` for backward-compat with the v2.9 single-face orchestrator path. Project page shows a colored badge with all locked characters.
   - New endpoint: `POST /api/upload/character-face` (multipart **or** `{imageUrl}` JSON; size cap 10 MB; protocol whitelist `http(s):` / `data:`)
   - New component: `components/create/character-lock-section.tsx`

--- a/README.md
+++ b/README.md
@@ -520,13 +520,13 @@ Every model call is provider-pluggable (priority chain + automatic fallback). Cr
 | **Creative LLM** (writer / director) | `deepseek-v4-pro` (`OPENAI_CREATIVE_MODEL`) + `deepseek-v4-flash` fast tier for drafts/polish | `MiniMax-M2.7` (`LLM_FALLBACK_MODEL`) |
 | **General LLM** (planning / validation / Vision-Audit) | `claude-sonnet-4-6` (`OPENAI_MODEL`) | `MiniMax-M2.7` |
 | **Video** | `veo3.1-pro` (`VEO_MODEL`) | `veo3.1` · Kling → **MiniMax Hailuo** (Sora-2 retired — API EOL 2026-09-24) |
-| **Image** | `flux.1-kontext-pro` (`IMAGE_MODEL`) | Midjourney (`mj_imagine`) · fal FLUX Kontext · local ComfyUI → **MiniMax image** |
+| **Image** | `flux.1-kontext-pro` (`IMAGE_MODEL`) | Midjourney (`mj_imagine`) · Atlas Cloud Seedream (opt-in) · fal FLUX Kontext · local ComfyUI → **MiniMax image** |
 | **TTS / voiceover** | `gpt-4o-mini-tts` (`VE_TTS_MODEL`) | MiniMax T2A (`speech-02-hd`) |
 | **Music / BGM** | MiniMax music | (Suno when gateway channel available) |
 
 - **Why two LLM tiers**: the creative tier (DeepSeek `-pro`, a reasoning model) carries writer/director quality work; the general tier (Claude `sonnet-4-6`) handles high-frequency planning / validation / Vision-Audit; the `-flash` tier keeps draft-compare & basic polish at sub-second latency.
 - **MiniMax safety net**: any primary LLM / video / image failure auto-routes to MiniMax (OpenAI-compatible) — surfaced live on the **API Health Board** (正常 / 额度用尽 / 配置缺失 / 不可达).
-- **Swap anything** in `.env.local` (`OPENAI_*` / `OPENAI_CREATIVE_*` / `VEO_*` / `IMAGE_MODEL` / `VE_TTS_MODEL` / `MINIMAX_*`) — zero code change. See [`docs/llm-providers.md`](docs/llm-providers.md).
+- **Swap anything** in `.env.local` (`OPENAI_*` / `OPENAI_CREATIVE_*` / `ATLASCLOUD_*` / `VEO_*` / `IMAGE_MODEL` / `VE_TTS_MODEL` / `MINIMAX_*`) — zero code change. See [`docs/llm-providers.md`](docs/llm-providers.md).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -374,7 +374,7 @@ KPI 卡: 平均冲突分 / 反转数 / 通过状态. 每镜柱状图 + 反转 ar
 - **为什么分开**:主网关跑最新顶级模型;补全网关补上缺的能力(TTS / MJ / Kling),并在主网关额度耗尽时接住。
 - **v6.8** — 主 LLM/视频/图像切到已充值网关 + 最强模型,顺带修了旧网关视频阶段的 `429 上游饱和` 报错。
 - **v6.9** — 新增独立 TTS provider(`lib/tts-providers/vectorengine-tts.ts`),配音不再依赖各家 group-id 配置;Midjourney 接成图像兜底;[API 健康看板](#-v6-新增--从能跑的-demo-进化成能用的工作室)显示**各网关用量 + 余额**。
-- **随时可换**:改 `.env.local`(`OPENAI_*` / `VEO_*` / `IMAGE_MODEL` / `MINIMAX_*`),0 改代码。详见 [`docs/llm-providers.md`](docs/llm-providers.md)。
+- **随时可换**:改 `.env.local`(`OPENAI_*` / `ATLASCLOUD_*` / `VEO_*` / `IMAGE_MODEL` / `MINIMAX_*`),0 改代码。Atlas Cloud Seedream 通过显式开关加入图像 fallback 链，不改变默认 provider。详见 [`docs/llm-providers.md`](docs/llm-providers.md)。
 
 ---
 

--- a/lib/image-providers/atlascloud-image.ts
+++ b/lib/image-providers/atlascloud-image.ts
@@ -1,0 +1,139 @@
+/** Atlas Cloud asynchronous text-to-image provider. */
+import { registerImageProvider } from './registry';
+import type { AspectRatio, ImageGenerateInput } from './types';
+
+const DEFAULT_BASE_URL = 'https://api.atlascloud.ai';
+const DEFAULT_MODEL = 'bytedance/seedream-v5.0-lite';
+const TERMINAL_FAILURES = new Set(['failed', 'timeout', 'canceled']);
+
+type FetchLike = typeof fetch;
+type Sleep = (ms: number) => Promise<void>;
+
+interface AtlasCloudDeps {
+  fetch?: FetchLike;
+  sleep?: Sleep;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+}
+
+function responseData(payload: unknown): Record<string, unknown> {
+  const body = payload as { code?: number; message?: string; msg?: string; data?: unknown };
+  if (body?.code != null && body.code !== 0 && body.code !== 200) {
+    throw new Error(`Atlas Cloud API error: ${body.message || body.msg || body.code}`);
+  }
+  const data = body?.data ?? body;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Atlas Cloud returned an invalid response');
+  }
+  return data as Record<string, unknown>;
+}
+
+export function atlasCloudImageSize(aspect?: AspectRatio): string {
+  switch (aspect) {
+    case '9:16': return '1600*2848';
+    case '3:4': return '1664*2496';
+    case '4:3': return '2496*1664';
+    case '2.35:1': return '3136*1344';
+    case '1:1': return '2048*2048';
+    default: return '2848*1600';
+  }
+}
+
+export function buildAtlasCloudImageRequest(
+  input: ImageGenerateInput,
+  env: NodeJS.ProcessEnv = process.env,
+): { model: string; prompt: string; size: string; output_format: 'jpeg' | 'png' } {
+  return {
+    model: env.ATLASCLOUD_IMAGE_MODEL || DEFAULT_MODEL,
+    prompt: input.prompt,
+    size: atlasCloudImageSize(input.aspectRatio),
+    output_format: env.ATLASCLOUD_IMAGE_OUTPUT_FORMAT === 'png' ? 'png' : 'jpeg',
+  };
+}
+
+export function hasAtlasCloudImage(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.ATLASCLOUD_IMAGE_ENABLED === '1' && !!env.ATLASCLOUD_API_KEY;
+}
+
+async function readJson(res: Response, label: string): Promise<Record<string, unknown>> {
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${label} ${res.status}: ${text.slice(0, 160)}`);
+  }
+  return responseData(await res.json());
+}
+
+export async function generateAtlasCloudImage(
+  input: ImageGenerateInput,
+  env: NodeJS.ProcessEnv = process.env,
+  deps: AtlasCloudDeps = {},
+): Promise<{ imageUrl: string; predictionId: string }> {
+  const fetchImpl = deps.fetch || fetch;
+  const sleep = deps.sleep || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const base = (env.ATLASCLOUD_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const key = env.ATLASCLOUD_API_KEY || '';
+  if (!key) throw new Error('ATLASCLOUD_API_KEY is required');
+
+  // Submit exactly once. Retrying an ambiguous POST could create a duplicate billable job.
+  const submitted = await fetchImpl(`${base}/api/v1/model/generateImage`, {
+    method: 'POST',
+    signal: AbortSignal.timeout(120_000),
+    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(buildAtlasCloudImageRequest(input, env)),
+  });
+  const submitData = await readJson(submitted, 'Atlas Cloud image submit');
+  const predictionId = String(submitData.id || submitData.request_id || '');
+  if (!predictionId) throw new Error('Atlas Cloud submit returned no prediction id');
+
+  const pollIntervalMs = deps.pollIntervalMs ?? 3_000;
+  const pollTimeoutMs = deps.pollTimeoutMs ?? Number(env.ATLASCLOUD_IMAGE_POLL_TIMEOUT_MS || 300_000);
+  const deadline = Date.now() + pollTimeoutMs;
+  while (Date.now() < deadline) {
+    let pollData: Record<string, unknown> | null = null;
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const polled = await fetchImpl(`${base}/api/v1/model/prediction/${encodeURIComponent(predictionId)}`, {
+          method: 'GET',
+          signal: AbortSignal.timeout(60_000),
+          headers: { Authorization: `Bearer ${key}` },
+        });
+        pollData = await readJson(polled, 'Atlas Cloud image poll');
+        break;
+      } catch (error) {
+        lastError = error;
+        if (attempt < 2) await sleep(250 * (2 ** attempt));
+      }
+    }
+    if (!pollData) throw lastError instanceof Error ? lastError : new Error('Atlas Cloud poll failed');
+
+    const status = String(pollData.status || '').toLowerCase();
+    if (status === 'completed' || status === 'succeeded') {
+      const output = pollData.outputs ?? pollData.output;
+      const imageUrl = Array.isArray(output) ? output[0] : output;
+      if (typeof imageUrl !== 'string' || !/^https?:\/\//.test(imageUrl)) {
+        throw new Error('Atlas Cloud completed without an image URL');
+      }
+      return { imageUrl, predictionId };
+    }
+    if (TERMINAL_FAILURES.has(status)) {
+      throw new Error(`Atlas Cloud image generation ${status}: ${String(pollData.error || pollData.message || '')}`);
+    }
+    await sleep(pollIntervalMs);
+  }
+  throw new Error(`Atlas Cloud image generation timed out after ${pollTimeoutMs}ms`);
+}
+
+registerImageProvider({
+  id: 'atlascloud-image',
+  name: 'Atlas Cloud (Seedream)',
+  supportsRefs: false,
+  maxRefImages: 0,
+  priority: 65,
+  available: () => hasAtlasCloudImage(),
+  async generate(input) {
+    const result = await generateAtlasCloudImage(input);
+    input.onProgress?.(1, 'atlascloud-image: done');
+    return { imageUrl: result.imageUrl, provider: 'atlascloud-image', upstreamId: result.predictionId };
+  },
+});

--- a/lib/image-providers/builtins.ts
+++ b/lib/image-providers/builtins.ts
@@ -23,6 +23,7 @@ import '@/lib/mock-providers'; // v10.4.0: mock 三件套常驻注册(MOCK_ENGIN
 // 各自的 available() 按 env 门控(未配 key/未开开关就自动不参与,零副作用)。
 import '@/lib/image-providers/openai-gpt-image';
 import '@/lib/image-providers/gemini-image';
+import '@/lib/image-providers/atlascloud-image';
 
 // ─── Lazy service factory — 避免 server 启动就加载所有 service ────────────
 // 因为 service class 在 constructor 里读 API_CONFIG (.env), 这里用 lazy + 缓存

--- a/tests/atlascloud-image-provider.test.ts
+++ b/tests/atlascloud-image-provider.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  atlasCloudImageSize,
+  buildAtlasCloudImageRequest,
+  generateAtlasCloudImage,
+  hasAtlasCloudImage,
+} from '@/lib/image-providers/atlascloud-image';
+
+const env = {
+  ATLASCLOUD_API_KEY: 'test-key',
+  ATLASCLOUD_IMAGE_ENABLED: '1',
+  ATLASCLOUD_IMAGE_MODEL: 'bytedance/seedream-v5.0-lite',
+} as NodeJS.ProcessEnv;
+
+describe('Atlas Cloud image provider', () => {
+  it('is opt-in and requires a key', () => {
+    expect(hasAtlasCloudImage({ ATLASCLOUD_API_KEY: 'key' })).toBe(false);
+    expect(hasAtlasCloudImage({ ATLASCLOUD_IMAGE_ENABLED: '1' })).toBe(false);
+    expect(hasAtlasCloudImage(env)).toBe(true);
+  });
+
+  it('maps supported aspect ratios to live Seedream sizes', () => {
+    expect(atlasCloudImageSize('16:9')).toBe('2848*1600');
+    expect(atlasCloudImageSize('9:16')).toBe('1600*2848');
+    expect(atlasCloudImageSize('1:1')).toBe('2048*2048');
+    expect(buildAtlasCloudImageRequest({ prompt: 'shot', aspectRatio: '4:3' }, env)).toEqual({
+      model: 'bytedance/seedream-v5.0-lite',
+      prompt: 'shot',
+      size: '2496*1664',
+      output_format: 'jpeg',
+    });
+  });
+
+  it('submits once, polls the same prediction, and returns its output', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 200, data: { id: 'pred-1' } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 200, data: { status: 'processing' } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        code: 200,
+        data: { status: 'completed', outputs: ['https://cdn.example/result.jpeg'] },
+      }), { status: 200 }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await generateAtlasCloudImage(
+      { prompt: 'cinematic shot', aspectRatio: '16:9' },
+      env,
+      { fetch: fetchMock as typeof fetch, sleep, pollIntervalMs: 1, pollTimeoutMs: 10_000 },
+    );
+
+    expect(result).toEqual({ imageUrl: 'https://cdn.example/result.jpeg', predictionId: 'pred-1' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(1);
+    expect(fetchMock.mock.calls[1][0]).toContain('/prediction/pred-1');
+    expect(sleep).toHaveBeenCalledWith(1);
+  });
+
+  it('never retries a failed submit', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ambiguous timeout'));
+    await expect(generateAtlasCloudImage(
+      { prompt: 'shot' },
+      env,
+      { fetch: fetchMock as typeof fetch, sleep: vi.fn(), pollTimeoutMs: 100 },
+    )).rejects.toThrow('ambiguous timeout');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Adds an opt-in Atlas Cloud Seedream text-to-image provider to the existing image-provider registry, including environment documentation and tests.

## Why

This gives deployments another real image fallback without changing the default provider chain. The adapter preserves reference-image semantics by declaring that it cannot handle references, so reference-bound shots skip it instead of silently dropping inputs.

## How

The provider submits one asynchronous generation request, polls only that prediction with bounded GET retries, validates the final HTTP(S) image URL, and returns the prediction ID as the upstream ID. Billable POST submissions are never retried. A live smoke run produced a valid 2848x1600 JPEG.

## Checklist

- [ ] Tests pass (`npm test`) — 5518 passed; 7 unrelated environment/timing tests failed (missing `ffmpeg-static` binary, local CJK font selection, DNS-based SSRF assertion, and existing 5-second gate/pipeline timeouts)
- [x] Typecheck clean (`npm run typecheck`)
- [x] Added or updated tests for changed behavior
- [x] Updated `.env.example` if a new env var was introduced
- [x] Updated `ROADMAP.md` / `CHANGELOG.md` if this closes a roadmap item
- [x] No `console.log` left in committed code
- [x] No `.env.local` or other secret-bearing files staged

Additional verification: `npm run build` passed; 36 focused provider/registry/integration tests passed. The repository `npm run lint` script currently invokes removed Next.js 16 `next lint` behavior and fails before linting files.

## Screenshots / demo (if UI)

Not applicable; provider-only change.